### PR TITLE
chore: remove @efiop from maintainers

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -67,5 +67,4 @@ extra:
   recipe-maintainers:
     - casperdcl
     - '0x2b3bfa0'
-    - efiop
     - shcheklein


### PR DESCRIPTION
Remove `efiop` from this feedstock's recipe maintainer list because I am stepping away from conda-forge maintenance.

The other listed maintainer or maintainers remain unchanged. This does not change the package, recipe requirements, or build output.

Validation: the diff contains exactly one deleted maintainer entry and passes `git diff --check`.
